### PR TITLE
Updating to accomodate task grouping as well as ranging

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,7 @@ source := `<?xml version='1.0'?>
 	var info JobInfo
 	xml.Unmarshal([]byte(source), &info)
 ```
+
+#Environment Variables
+GOGRIDENGINE_TEST : If set to "true", will trigger test mode where the library will look to generated content and not try to use qstat
+GOGRIDENGINE_TEST_SOURCE: If set, should be a URL to XML from `qstat -xml` output which will be used for testing

--- a/job.go
+++ b/job.go
@@ -2,7 +2,6 @@ package gogridengine
 
 import (
 	"encoding/xml"
-	"errors"
 	"sort"
 	"strconv"
 	"strings"
@@ -10,13 +9,18 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+//Error allows us to define constant errors
+type Error string
+
+func (e Error) Error() string { return string(e) }
+
 const (
 	//TASKRANGEIDENTIFIERREGEX is a regex string used for identifying whether <tasks> objects indicate a range of tasks (normally only expressed on pending tasks)
 	TASKRANGEIDENTIFIERREGEX string = `[0-9]{1,}-[0-9]{1,}:[0-9]`
 )
 
 //ErrInvalidTaskRangeIdentifier is an error that identifies jobs with a non-range conformant task attribute. Basically means you're trying to extrapolate jobs from a task range that isn't really a task range.
-var ErrInvalidTaskRangeIdentifier error = errors.New("The provided job does not actually indicate a range or group of tasks")
+const ErrInvalidTaskRangeIdentifier = Error("The provided job does not actually indicate a range or group of tasks")
 
 //Task is an element used for handling task arrays from the grid engine. Here we'll store the raw value (Source) and the TaskID if an individual identifier.
 type Task struct {

--- a/job.go
+++ b/job.go
@@ -16,7 +16,7 @@ const (
 )
 
 //ErrInvalidTaskRangeIdentifier is an error that identifies jobs with a non-range conformant task attribute. Basically means you're trying to extrapolate jobs from a task range that isn't really a task range.
-var ErrInvalidTaskRangeIdentifier error = errors.New("The provided job does not actually indicate a range of tasks")
+var ErrInvalidTaskRangeIdentifier error = errors.New("The provided job does not actually indicate a range or group of tasks")
 
 //Task is an element used for handling task arrays from the grid engine. Here we'll store the raw value (Source) and the TaskID if an individual identifier.
 type Task struct {
@@ -169,38 +169,64 @@ func DoesJobContainTaskRange(j Job) bool {
 	return TaskRangeRegex.MatchString(j.Tasks.Source)
 }
 
+func DoesJobContainTaskGroup(j Job) bool {
+	return strings.Contains(j.Tasks.Source, ",")
+}
+
 //ExtrapolateTasksToJobs takes the role of finding the range identifier and returning a job list from it (Extrapolated from the task list)
 func ExtrapolateTasksToJobs(original Job) (JobList, error) {
 	var jl JobList
 
-	ok := DoesJobContainTaskRange(original)
+	ranged := DoesJobContainTaskRange(original)
+	group := DoesJobContainTaskGroup(original)
 
-	if !ok {
+	if !ranged && !group {
 		return JobList{}, ErrInvalidTaskRangeIdentifier
 	}
 
-	identifier := TaskRangeRegex.FindString(original.Tasks.Source)
+	if ranged {
+		identifier := TaskRangeRegex.FindString(original.Tasks.Source)
 
-	pieces := strings.Split(identifier, ":")
-	rangeComponent := pieces[0]
-	incrementor := pieces[1]
+		pieces := strings.Split(identifier, ":")
+		rangeComponent := pieces[0]
+		incrementor := pieces[1]
 
-	rangePieces := strings.Split(rangeComponent, "-")
-	begin := rangePieces[0]
-	end := rangePieces[1]
+		rangePieces := strings.Split(rangeComponent, "-")
+		begin := rangePieces[0]
+		end := rangePieces[1]
 
-	// Because we passed the regex to identify this earlier, there's no pathway to error here.
-	intrementor, _ := strconv.ParseInt(incrementor, 10, 64)
-	beginInt, _ := strconv.ParseInt(begin, 10, 64)
-	endInt, _ := strconv.ParseInt(end, 10, 64)
+		// Because we passed the regex to identify this earlier, there's no pathway to error here.
+		intrementor, _ := strconv.ParseInt(incrementor, 10, 64)
+		beginInt, _ := strconv.ParseInt(begin, 10, 64)
+		endInt, _ := strconv.ParseInt(end, 10, 64)
 
-	for i := beginInt; i <= endInt; i = i + intrementor {
-		lj := original
+		for i := beginInt; i <= endInt; i = i + intrementor {
+			lj := original
 
-		lj.Tasks.TaskID = i
+			lj.Tasks.TaskID = i
 
-		jl = append(jl, lj)
+			jl = append(jl, lj)
+		}
+
+	}
+
+	if group {
+		pieces := strings.Split(original.Tasks.Source, ",")
+
+		for _, v := range pieces {
+			gj := original
+			taskID, err := strconv.Atoi(v)
+
+			if err != nil {
+				return JobList{}, err
+			}
+
+			gj.Tasks.TaskID = int64(taskID)
+
+			jl = append(jl, gj)
+		}
 	}
 
 	return jl, nil
+
 }

--- a/job.go
+++ b/job.go
@@ -169,6 +169,7 @@ func DoesJobContainTaskRange(j Job) bool {
 	return TaskRangeRegex.MatchString(j.Tasks.Source)
 }
 
+//DoesJobContainTaskGroup evaluates whether the XML marshalled tasks value contains a group rather than a range of tasks
 func DoesJobContainTaskGroup(j Job) bool {
 	return strings.Contains(j.Tasks.Source, ",")
 }

--- a/qstat.go
+++ b/qstat.go
@@ -191,7 +191,14 @@ func buildQstatArgumentList(filters map[string]string) []string {
 func generatedQstatOputput() (string, error) {
 	//Get the medium XML file from the master repo
 
-	xmlresponse, err := http.Get("https://raw.githubusercontent.com/metrumresearchgroup/gogridengine/master/test_data/medium.xml")
+	//Default
+	xmlsource := "https://raw.githubusercontent.com/metrumresearchgroup/gogridengine/master/test_data/medium.xml"
+
+	if os.Getenv("GOGRIDENGINE_TEST_SOURCE") != "" {
+		xmlsource = os.Getenv("GOGRIDENGINE_TEST_SOURCE")
+	}
+
+	xmlresponse, err := http.Get(xmlsource)
 
 	if err != nil {
 		return "", err

--- a/qstat_test.go
+++ b/qstat_test.go
@@ -1,6 +1,7 @@
 package gogridengine
 
 import (
+	"encoding/xml"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -208,4 +209,17 @@ func Test_generatedQstatOputput(t *testing.T) {
 	output, _ := generatedQstatOputput()
 	assert.NotEmpty(t, output)
 
+}
+
+func Test_Select_Source_For_Test(t *testing.T) {
+	os.Setenv("GOGRIDENGINE_TEST", "true")
+	os.Setenv("GOGRIDENGINE_TEST_SOURCE", "https://gist.githubusercontent.com/shairozan/03f6f6123b11483bb17fd2c6ee95c338/raw/d65e6d603e7563b7307f9b045171ea7693c95f40/small_sge.xml")
+
+	out, _ := GetQstatOutput(make(map[string]string))
+	ji := JobInfo{}
+	xml.Unmarshal([]byte(out), &ji)
+
+	assert.NotEmpty(t, ji)
+	assert.NotNil(t, ji)
+	assert.Equal(t, ji.QueueInfo.Queues[0].JobList[0].JBJobNumber, int64(612))
 }

--- a/test_data/small.xml
+++ b/test_data/small.xml
@@ -1,0 +1,204 @@
+<?xml version='1.0'?>
+<job_info  xmlns:xsd="http://arc.liv.ac.uk/repos/darcs/sge/source/dist/util/resources/schemas/qstat/qstat.xsd">
+  <queue_info>
+    <Queue-List>
+      <name>all.q@ip-10-0-1-113.ec2.internal</name>
+      <qtype>BIP</qtype>
+      <slots_used>5</slots_used>
+      <slots_resv>0</slots_resv>
+      <slots_total>8</slots_total>
+      <load_avg>0.34000</load_avg>
+      <arch>lx-amd64</arch>
+      <resource name="load_avg" type="hl">0.340000</resource>
+      <resource name="load_short" type="hl">0.080000</resource>
+      <resource name="load_medium" type="hl">0.340000</resource>
+      <resource name="load_long" type="hl">0.200000</resource>
+      <resource name="arch" type="hl">lx-amd64</resource>
+      <resource name="num_proc" type="hl">8</resource>
+      <resource name="mem_free" type="hl">14.101G</resource>
+      <resource name="swap_free" type="hl">0.000</resource>
+      <resource name="virtual_free" type="hl">14.101G</resource>
+      <resource name="mem_total" type="hl">14.688G</resource>
+      <resource name="swap_total" type="hl">0.000</resource>
+      <resource name="virtual_total" type="hl">14.688G</resource>
+      <resource name="mem_used" type="hl">601.070M</resource>
+      <resource name="swap_used" type="hl">0.000</resource>
+      <resource name="virtual_used" type="hl">601.070M</resource>
+      <resource name="cpu" type="hl">0.600000</resource>
+      <resource name="m_topology" type="hl">SCTTCTTCTTCTT</resource>
+      <resource name="m_topology_inuse" type="hl">SCTTCTTCTTCTT</resource>
+      <resource name="m_socket" type="hl">1</resource>
+      <resource name="m_core" type="hl">4</resource>
+      <resource name="m_thread" type="hl">8</resource>
+      <resource name="np_load_avg" type="hl">0.042500</resource>
+      <resource name="np_load_short" type="hl">0.010000</resource>
+      <resource name="np_load_medium" type="hl">0.042500</resource>
+      <resource name="np_load_long" type="hl">0.025000</resource>
+      <resource name="qname" type="qf">all.q</resource>
+      <resource name="hostname" type="qf">ip-10-0-1-113.ec2.internal</resource>
+      <resource name="slots" type="qc">3</resource>
+      <resource name="tmpdir" type="qf">/tmp</resource>
+      <resource name="seq_no" type="qf">0</resource>
+      <resource name="rerun" type="qf">0.000000</resource>
+      <resource name="calendar" type="qf">NONE</resource>
+      <resource name="s_rt" type="qf">infinity</resource>
+      <resource name="h_rt" type="qf">infinity</resource>
+      <resource name="s_cpu" type="qf">infinity</resource>
+      <resource name="h_cpu" type="qf">infinity</resource>
+      <resource name="s_fsize" type="qf">infinity</resource>
+      <resource name="h_fsize" type="qf">infinity</resource>
+      <resource name="s_data" type="qf">infinity</resource>
+      <resource name="h_data" type="qf">infinity</resource>
+      <resource name="s_stack" type="qf">infinity</resource>
+      <resource name="h_stack" type="qf">infinity</resource>
+      <resource name="s_core" type="qf">infinity</resource>
+      <resource name="h_core" type="qf">infinity</resource>
+      <resource name="s_rss" type="qf">infinity</resource>
+      <resource name="h_rss" type="qf">infinity</resource>
+      <resource name="s_vmem" type="qf">infinity</resource>
+      <resource name="h_vmem" type="qf">infinity</resource>
+      <resource name="min_cpu_interval" type="qf">00:05:00</resource>
+      <job_list state="running">
+        <JB_job_number>612</JB_job_number>
+        <JAT_prio>0.55500</JAT_prio>
+        <JB_name>Executable_MTP001.sh</JB_name>
+        <JB_owner>darrellb</JB_owner>
+        <state>r</state>
+        <JAT_start_time>2019-12-18T15:28:27</JAT_start_time>
+        <slots>1</slots>
+      </job_list>
+      <job_list state="running">
+        <JB_job_number>614</JB_job_number>
+        <JAT_prio>0.55500</JAT_prio>
+        <JB_name>Executable_MTP003.sh</JB_name>
+        <JB_owner>darrellb</JB_owner>
+        <state>r</state>
+        <JAT_start_time>2019-12-18T15:28:27</JAT_start_time>
+        <slots>1</slots>
+      </job_list>
+      <job_list state="running">
+        <JB_job_number>616</JB_job_number>
+        <JAT_prio>0.55500</JAT_prio>
+        <JB_name>Executable_MTP005.sh</JB_name>
+        <JB_owner>darrellb</JB_owner>
+        <state>r</state>
+        <JAT_start_time>2019-12-18T15:28:27</JAT_start_time>
+        <slots>1</slots>
+      </job_list>
+      <job_list state="running">
+        <JB_job_number>618</JB_job_number>
+        <JAT_prio>0.55500</JAT_prio>
+        <JB_name>Executable_MTP007.sh</JB_name>
+        <JB_owner>darrellb</JB_owner>
+        <state>r</state>
+        <JAT_start_time>2019-12-18T15:28:27</JAT_start_time>
+        <slots>1</slots>
+      </job_list>
+      <job_list state="running">
+        <JB_job_number>620</JB_job_number>
+        <JAT_prio>0.55500</JAT_prio>
+        <JB_name>Executable_MTP009.sh</JB_name>
+        <JB_owner>darrellb</JB_owner>
+        <state>r</state>
+        <JAT_start_time>2019-12-18T15:28:27</JAT_start_time>
+        <slots>1</slots>
+      </job_list>
+    </Queue-List>
+    <Queue-List>
+      <name>all.q@ip-10-0-1-203.ec2.internal</name>
+      <qtype>BIP</qtype>
+      <slots_used>4</slots_used>
+      <slots_resv>0</slots_resv>
+      <slots_total>8</slots_total>
+      <load_avg>0.66000</load_avg>
+      <arch>lx-amd64</arch>
+      <resource name="load_avg" type="hl">0.660000</resource>
+      <resource name="load_short" type="hl">0.050000</resource>
+      <resource name="load_medium" type="hl">0.660000</resource>
+      <resource name="load_long" type="hl">0.630000</resource>
+      <resource name="arch" type="hl">lx-amd64</resource>
+      <resource name="num_proc" type="hl">8</resource>
+      <resource name="mem_free" type="hl">14.116G</resource>
+      <resource name="swap_free" type="hl">0.000</resource>
+      <resource name="virtual_free" type="hl">14.116G</resource>
+      <resource name="mem_total" type="hl">14.688G</resource>
+      <resource name="swap_total" type="hl">0.000</resource>
+      <resource name="virtual_total" type="hl">14.688G</resource>
+      <resource name="mem_used" type="hl">585.020M</resource>
+      <resource name="swap_used" type="hl">0.000</resource>
+      <resource name="virtual_used" type="hl">585.020M</resource>
+      <resource name="cpu" type="hl">0.600000</resource>
+      <resource name="m_topology" type="hl">SCTTCTTCTTCTT</resource>
+      <resource name="m_topology_inuse" type="hl">SCTTCTTCTTCTT</resource>
+      <resource name="m_socket" type="hl">1</resource>
+      <resource name="m_core" type="hl">4</resource>
+      <resource name="m_thread" type="hl">8</resource>
+      <resource name="np_load_avg" type="hl">0.082500</resource>
+      <resource name="np_load_short" type="hl">0.006250</resource>
+      <resource name="np_load_medium" type="hl">0.082500</resource>
+      <resource name="np_load_long" type="hl">0.078750</resource>
+      <resource name="qname" type="qf">all.q</resource>
+      <resource name="hostname" type="qf">ip-10-0-1-203.ec2.internal</resource>
+      <resource name="slots" type="qc">4</resource>
+      <resource name="tmpdir" type="qf">/tmp</resource>
+      <resource name="seq_no" type="qf">0</resource>
+      <resource name="rerun" type="qf">0.000000</resource>
+      <resource name="calendar" type="qf">NONE</resource>
+      <resource name="s_rt" type="qf">infinity</resource>
+      <resource name="h_rt" type="qf">infinity</resource>
+      <resource name="s_cpu" type="qf">infinity</resource>
+      <resource name="h_cpu" type="qf">infinity</resource>
+      <resource name="s_fsize" type="qf">infinity</resource>
+      <resource name="h_fsize" type="qf">infinity</resource>
+      <resource name="s_data" type="qf">infinity</resource>
+      <resource name="h_data" type="qf">infinity</resource>
+      <resource name="s_stack" type="qf">infinity</resource>
+      <resource name="h_stack" type="qf">infinity</resource>
+      <resource name="s_core" type="qf">infinity</resource>
+      <resource name="h_core" type="qf">infinity</resource>
+      <resource name="s_rss" type="qf">infinity</resource>
+      <resource name="h_rss" type="qf">infinity</resource>
+      <resource name="s_vmem" type="qf">infinity</resource>
+      <resource name="h_vmem" type="qf">infinity</resource>
+      <resource name="min_cpu_interval" type="qf">00:05:00</resource>
+      <job_list state="running">
+        <JB_job_number>613</JB_job_number>
+        <JAT_prio>0.55500</JAT_prio>
+        <JB_name>Executable_MTP002.sh</JB_name>
+        <JB_owner>darrellb</JB_owner>
+        <state>r</state>
+        <JAT_start_time>2019-12-18T15:28:27</JAT_start_time>
+        <slots>1</slots>
+      </job_list>
+      <job_list state="running">
+        <JB_job_number>615</JB_job_number>
+        <JAT_prio>0.55500</JAT_prio>
+        <JB_name>Executable_MTP004.sh</JB_name>
+        <JB_owner>darrellb</JB_owner>
+        <state>r</state>
+        <JAT_start_time>2019-12-18T15:28:27</JAT_start_time>
+        <slots>1</slots>
+      </job_list>
+      <job_list state="running">
+        <JB_job_number>617</JB_job_number>
+        <JAT_prio>0.55500</JAT_prio>
+        <JB_name>Executable_MTP006.sh</JB_name>
+        <JB_owner>darrellb</JB_owner>
+        <state>r</state>
+        <JAT_start_time>2019-12-18T15:28:27</JAT_start_time>
+        <slots>1</slots>
+      </job_list>
+      <job_list state="running">
+        <JB_job_number>619</JB_job_number>
+        <JAT_prio>0.55500</JAT_prio>
+        <JB_name>Executable_MTP008.sh</JB_name>
+        <JB_owner>darrellb</JB_owner>
+        <state>r</state>
+        <JAT_start_time>2019-12-18T15:28:27</JAT_start_time>
+        <slots>1</slots>
+      </job_list>
+    </Queue-List>
+  </queue_info>
+  <job_info>
+  </job_info>
+</job_info>


### PR DESCRIPTION
This branch accomodates SGE task arrays and their serialization. It does this by the following:

- Tasks are Extrapolated out into individual jobs

    - Ranges ("1-5:1") are extrapolated into a list of jobs by incrementing across the values provided
    - Groups ("2,4,6") Are split on the delimiter and cloned from the source job with only the TaskID Changing 